### PR TITLE
Dependency libraries improved in `ecuacion-util-poi`.

### DIFF
--- a/ecuacion-util-poi-sample/pom.xml
+++ b/ecuacion-util-poi-sample/pom.xml
@@ -71,6 +71,11 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-to-slf4j</artifactId>
+			<version>2.24.3</version>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>1.5.15</version>

--- a/ecuacion-util-poi/README.md
+++ b/ecuacion-util-poi/README.md
@@ -24,7 +24,6 @@
 
 - `org.apache.poi:poi`
 - `org.apache.poi:poi-ooxml`
-- `org.apache.logging.log4j.log4j-to-slf4j` (To use any slf4j-compatible logging modules)
 
 ### Manual Load Needed Libraries
 
@@ -32,10 +31,13 @@
 - (any `jakarta.validation:jakarta.validation-api` compatible Bean Validation libraries. `org.hibernate.validator:hibernate-validator` and `org.glassfish:jakarta.el` are recommended.)
 - `jakarta.annotation:jakarta.annotation-api`
 - `org.slf4j:slf4j-api`
-- (any `org.slf4j:slf4j-api` compatible logging libraries. `ch.qos.logback:logback-classic` is recommended.)
+- (if you use log4j2, add `org.apache.logging.log4j:log4j-slf4j-impl` and `org.apache.logging.log4j:log4j-core`,
+   or else `org.apache.logging.log4j.log4j-to-slf4j` (To use any slf4j-compatible logging modules) and any `org.slf4j:slf4j-api` compatible logging libraries. `ch.qos.logback:logback-classic` is recommended.)
 
 (modules depending on `ecuacion-lib-core`)
 - `jakarta.mail:jakarta.mail-api` (If you want to use the mail related utility: `jp.ecuacion.lib.core.util.MailUtil`)
+
+Since the dependency libraries are a little complicated, we recommend to refer `pom.xml` in `ecuacion-util-poi-sample`. 
 
 ## Documentation
 

--- a/ecuacion-util-poi/pom.xml
+++ b/ecuacion-util-poi/pom.xml
@@ -82,6 +82,16 @@
 			<artifactId>jakarta.annotation-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		 <dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>jakarta.el</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- ecuacion-lib -->
 		<dependency>
@@ -109,12 +119,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<!-- Needed to use slf4j from POI -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-to-slf4j</artifactId>
-			<version>${org.apache.logging.log4j.log4j-to-slf4j.version}</version>
 		</dependency>
 
 		<!-- unit test -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
 	<properties>
 		<ecuacion-utils.version>0.0.1-SNAPSHOT</ecuacion-utils.version>
 		<org.apache.poi.version>5.4.0</org.apache.poi.version>
-		<org.apache.logging.log4j.log4j-to-slf4j.version>2.24.3</org.apache.logging.log4j.log4j-to-slf4j.version>
 	</properties>
 	
 	<dependencyManagement>


### PR DESCRIPTION
- Implementations for `BeanValidation` are needed for test.
- `org.apache.logging.log4j:log4j-to-slf4j` should not be dependent because when the user uses `log4j2` as logger it won't be needed.