### PR TITLE
#128: Now `NPE` not occurs when the far left cell of the header of the

### DIFF
--- a/ecuacion-util-poi/src/main/java/jp/ecuacion/util/poi/excel/table/reader/ExcelTableReader.java
+++ b/ecuacion-util-poi/src/main/java/jp/ecuacion/util/poi/excel/table/reader/ExcelTableReader.java
@@ -244,6 +244,11 @@ public abstract class ExcelTableReader<T> extends ExcelTable<T> implements IfExc
     // the folloing is executed when tableColumnSize value needs to be analyzed dynamically.
 
     Row row = sheet.getRow(poiBasisDeterminedTableStartRowNumber);
+    if (row == null) {
+      String msg = "jp.ecuacion.util.poi.excel.reader."
+          + "RowNotSupposedToBeNullSinceItsTheFarLeftCellOfHeaderRow.message";
+      throw new BizLogicAppException(msg);
+    }
 
     // This row is the line with header, which cannot be {@code null}.
     ObjectsUtil.requireNonNull(row);
@@ -358,7 +363,7 @@ public abstract class ExcelTableReader<T> extends ExcelTable<T> implements IfExc
         } catch (LoopBreakException ex) {
           hasNext = false;
         }
-        
+
         return rtn;
 
       } catch (BizLogicAppException ex) {
@@ -367,7 +372,7 @@ public abstract class ExcelTableReader<T> extends ExcelTable<T> implements IfExc
 
     }
   }
-  
+
   /**
    * Sets {@code suppressesWarnLog}.
    * 

--- a/ecuacion-util-poi/src/main/resources/messages_util_poi.properties
+++ b/ecuacion-util-poi/src/main/resources/messages_util_poi.properties
@@ -25,3 +25,4 @@ jp.ecuacion.util.poi.excel.ExcelWriteUtil.NotImplementedException.message.defaul
 jp.ecuacion.util.poi.excel.ExcelWriteUtil.NotImplementedException.ReasonUnknown.message.default=(unknown)
 jp.ecuacion.util.poi.excel.ExcelWriteUtil.NotImplementedException.ReasonUnimplementedFunction.message.default=unknown excel function: {0}
 jp.ecuacion.util.poi.excel.reader.ValidationMessagePostfix.message.default= (sheet name: {0})
+jp.ecuacion.util.poi.excel.reader.RowNotSupposedToBeNullSinceItsTheFarLeftCellOfHeaderRow.message.default=The far left cell of the table header row is empty (sheet name: {0}, cell: {1}, file info: {3})

--- a/ecuacion-util-poi/src/main/resources/messages_util_poi_ja.properties
+++ b/ecuacion-util-poi/src/main/resources/messages_util_poi_ja.properties
@@ -25,3 +25,4 @@ jp.ecuacion.util.poi.excel.ExcelWriteUtil.NotImplementedException.message.defaul
 jp.ecuacion.util.poi.excel.ExcelWriteUtil.NotImplementedException.ReasonUnknown.message.default=（理由不明）
 jp.ecuacion.util.poi.excel.ExcelWriteUtil.NotImplementedException.ReasonUnimplementedFunction.message.default=未対応の関数：{0}
 jp.ecuacion.util.poi.excel.reader.ValidationMessagePostfix.message.default=（シート名：{0}）
+jp.ecuacion.util.poi.excel.reader.RowNotSupposedToBeNullSinceItsTheFarLeftCellOfHeaderRow.message.default=表のヘッダ行の左端のセルが空欄です。確認してください。（sheet名：{0}、対象セル：{1}、未対応箇所：{2}、ファイル情報：{3}）


### PR DESCRIPTION
table is null .