### PR TITLE
#159: `CellOneLineHeaderExcelTableWriter#headerCheck` now does check.

### DIFF
--- a/ecuacion-util-poi/src/main/java/jp/ecuacion/util/poi/excel/table/writer/concrete/CellOneLineHeaderExcelTableWriter.java
+++ b/ecuacion-util-poi/src/main/java/jp/ecuacion/util/poi/excel/table/writer/concrete/CellOneLineHeaderExcelTableWriter.java
@@ -69,7 +69,7 @@ public class CellOneLineHeaderExcelTableWriter extends ExcelTableWriter<Cell>
       throws EncryptedDocumentException, AppException, IOException {
 
     new StringOneLineHeaderExcelTableReader(getSheetName(), getHeaderLabelData()[0],
-        tableStartRowNumber, tableStartColumnNumber, 1).read(workbook);
+        tableStartRowNumber - 1, tableStartColumnNumber, 1).read(workbook);
   }
 
   private Map<Integer, CellStyle> columnStyleMap = new HashMap<>();


### PR DESCRIPTION
Closes #159 